### PR TITLE
ORM and Database link [Finishes #111809308]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /test/coverage
 /*/.DS_Store
 /.byebug_history
+/app
+/db

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "bundler/gem_tasks"
 
-task :default => :test
+task default: :test
 task :test do
-  Dir.glob('./test/*_test.rb').each { |file| require file}
+  Dir.glob("./test/*_test.rb").each { |file| require file }
 end

--- a/hemp.gemspec
+++ b/hemp.gemspec
@@ -25,7 +25,9 @@ Gem::Specification.new do |spec|
           "pushes."
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
@@ -37,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "erubis"
   spec.add_development_dependency "tilt"
-  spec.add_development_dependency "mocha"
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "simplecov"
   spec.add_development_dependency "codeclimate-test-reporter"
 end

--- a/lib/hemp.rb
+++ b/lib/hemp.rb
@@ -1,6 +1,4 @@
 require "hemp/version"
 require "hemp/application"
 require "hemp/controller"
-
-module Hemp
-end
+require "hemp/base_record"

--- a/lib/hemp/base_record.rb
+++ b/lib/hemp/base_record.rb
@@ -1,0 +1,87 @@
+require "sqlite3"
+require "hemp/orm/property"
+require "hemp/orm/sql_helper"
+require "hemp/orm/record_interface"
+require "hemp/orm/class_instance_vars"
+
+module Hemp
+  class BaseRecord < Hemp::Orm::RecordInterface
+    include Hemp::Orm::ClassInstanceVars
+
+    def initialize(hash_arg = {})
+      self.class.expose_instance_vars
+      return super() if hash_arg.empty?
+      save_model_attributes hash_arg
+    end
+
+    def save_model_attributes(hash_arg)
+      row = []
+      properties.map do |property|
+        row << hash_arg.values_at(property.name)
+      end
+
+      self.class.set_instance_vars(self, row.flatten)
+    end
+
+    def save
+      row = self.class.find id
+      return update if row
+      SqlHelper.execute get_save_query
+
+      set_id_value
+    end
+
+    def set_id_value
+      id = SqlHelper.execute("select last_insert_rowid() "\
+        "from #{table_name}").first.first
+      instance_variable_set "@id", id
+    end
+
+    def update
+      SqlHelper.execute get_update_query
+    end
+
+    def destroy
+      self.class.destroy id
+    end
+
+    def get_save_query
+      sql_values = get_values.map { |val| %('#{val}') }.join(", ")
+
+      "insert into #{table_name} (#{sql_properties})"\
+        " values (#{sql_values})"
+    end
+
+    def get_update_query
+      sql_update_properties = get_update_values.join(", ")
+
+      "update #{table_name} set #{sql_update_properties}"\
+        " where id = #{id}"
+    end
+
+    def get_values
+      values = []
+      internal_props.each do |column|
+        values << (instance_variable_get("@#{column}") || "NULL")
+      end
+
+      values
+    end
+
+    def get_update_values
+      all_update_properties = []
+      values = get_values.map { |val| %('#{val}') }
+      values.each_with_index do |value, index|
+        all_update_properties << (internal_props[index].to_s + " = " + value)
+      end
+
+      all_update_properties
+    end
+
+    def ==(other)
+      instance_variables.each do |var|
+        instance_variable_get(var) == other.instance_variable_get(var)
+      end
+    end
+  end
+end

--- a/lib/hemp/dependencies.rb
+++ b/lib/hemp/dependencies.rb
@@ -1,0 +1,2 @@
+Dir["app/controllers/*"].each { |file| require file }
+Dir["app/models/*"].each { |file| require file }

--- a/lib/hemp/extensions/hash.rb
+++ b/lib/hemp/extensions/hash.rb
@@ -1,0 +1,10 @@
+class Hash
+  def slice(*args)
+    sliced_value = {}
+    args.each do |arg|
+      sliced_value[arg] = fetch(arg)
+    end
+
+    sliced_value
+  end
+end

--- a/lib/hemp/extensions/object.rb
+++ b/lib/hemp/extensions/object.rb
@@ -1,12 +1,10 @@
 require "facets"
 
-module Hemp
-  class ObjectHelper
-    def self.const_get(const_name)
-      Object.const_get const_name
-    rescue NameError
-      require const_name.to_s.pathize
-      Object.const_get const_name
-    end
+class Object
+  def self.const_missing(const_name)
+    require const_name.to_s.pathize
+    Object.const_get const_name
+  rescue LoadError
+    return
   end
 end

--- a/lib/hemp/orm/class_instance_vars.rb
+++ b/lib/hemp/orm/class_instance_vars.rb
@@ -1,0 +1,21 @@
+module Hemp
+  module Orm
+    module ClassInstanceVars
+      def properties
+        self.class.properties
+      end
+
+      def internal_props
+        self.class.internal_props
+      end
+
+      def sql_properties
+        self.class.sql_properties
+      end
+
+      def table_name
+        self.class.table_name
+      end
+    end
+  end
+end

--- a/lib/hemp/orm/property.rb
+++ b/lib/hemp/orm/property.rb
@@ -1,0 +1,41 @@
+module Hemp
+  module Orm
+    class Property
+      attr_reader :name, :options, :type, :primary_key, :nullable
+      def initialize(name, options = {})
+        @name = name
+        @options = options
+        parse_options
+      end
+
+      def parse_options
+        set_default_options
+        @options.each_pair do |key, value|
+          case key
+          when :type
+            instance_variable_set("@type", (value == :text ? "varchar" : value))
+          when :primary_key, :nullable
+            instance_variable_set("@#{key}", value)
+          end
+        end
+      end
+
+      def set_default_options
+        @type = "text"
+        @primary_key = false
+        @nullable = true
+      end
+
+      def to_s
+        "#{name} #{type}" <<
+          (nullable ? "" : " not null") <<
+          (primary_key ? " primary key" : "") <<
+          (primary_key && type == :integer ? " autoincrement" : "")
+      end
+
+      def ==(other)
+        name == other.name
+      end
+    end
+  end
+end

--- a/lib/hemp/orm/record_interface.rb
+++ b/lib/hemp/orm/record_interface.rb
@@ -1,0 +1,90 @@
+module Hemp
+  module Orm
+    class RecordInterface
+      SqlHelper = Hemp::Orm::SqlHelper
+
+      class << self
+        attr_accessor :table_name, :properties,
+                      :internal_props, :sql_properties
+
+        def to_table(name)
+          @table_name = name
+          property :id, type: :integer, primary_key: true
+        end
+
+        def property(name, options)
+          @properties ||= []
+          new_property = Property.new(name, options)
+          @properties << new_property unless @properties.include? new_property
+        end
+
+        def get_properties
+          props = @properties.map(&:name)
+          props.delete(:id)
+
+          props
+        end
+
+        def create_table
+          SqlHelper.execute "create table if not exists "\
+          "#{@table_name} (#{@properties.join(', ')})"
+
+          construct_sql_properties
+          expose_instance_vars
+        end
+
+        def construct_sql_properties
+          @internal_props = get_properties
+          @sql_properties = @internal_props.join(", ")
+        end
+
+        def expose_instance_vars
+          @properties.map(&:name).each do |name|
+            const_get(self.name).class_eval { attr_accessor name.to_sym }
+          end
+        end
+
+        def set_instance_vars(scope, row)
+          @properties.map(&:name).each_with_index do |name, index|
+            scope.instance_variable_set "@#{name}", row[index]
+          end
+        end
+
+        def initialize_model(row)
+          model = const_get(name).new
+          set_instance_vars(model, row)
+
+          model
+        end
+
+        def find(id)
+          row = SqlHelper.execute "select * from #{@table_name} "\
+          "where id = ?", [id]
+
+          return initialize_model(row.first) unless row.empty?
+          nil
+        end
+
+        def count
+          row = SqlHelper.execute "select count(*) from #{@table_name}"
+
+          row.first
+        end
+
+        def all
+          rows = SqlHelper.execute "select * from #{@table_name}"
+          rows.map { |row| initialize_model row }
+        end
+
+        def destroy(id)
+          SqlHelper.execute "delete from #{@table_name} "\
+          "where id = ?", [id]
+        end
+
+        def destroy_all
+          SqlHelper.execute "delete from #{@table_name}"
+        end
+      end
+    end
+  end
+end

--- a/lib/hemp/orm/sql_helper.rb
+++ b/lib/hemp/orm/sql_helper.rb
@@ -1,0 +1,14 @@
+require "fileutils"
+
+module Hemp
+  module Orm
+    module SqlHelper
+      FileUtils.mkdir_p "db"
+      @db = SQLite3::Database.new File.join "db", "development.sqlite3"
+
+      def self.execute(*sql_args)
+        @db.execute(*sql_args)
+      end
+    end
+  end
+end

--- a/lib/hemp/routing/route_syntax_error.rb
+++ b/lib/hemp/routing/route_syntax_error.rb
@@ -3,7 +3,7 @@ module Hemp
     class RouteSyntaxError < StandardError
       def initialize(method_path, custom_message = "")
         super "Error while parsing routes. "\
-        "See line containing #{method_path}. #{custom_message}"
+        "See line containing - '#{method_path}'. #{custom_message}"
       end
     end
   end

--- a/test/application_full_test.rb
+++ b/test/application_full_test.rb
@@ -1,5 +1,4 @@
 require_relative "test_helper"
-require "fileutils"
 
 class TestFullApplication < Minitest::Test
   attr_reader :full_application, :env, :file, :controller,
@@ -12,6 +11,11 @@ class TestFullApplication < Minitest::Test
       "RACK_INPUT" => ""
     }
     set_up_full_app_and_routes
+  end
+
+  def teardown
+    File.delete @controller
+    FileUtils.rm_rf "app"
   end
 
   def set_up_full_app_and_routes
@@ -91,7 +95,6 @@ class TestFullApplication < Minitest::Test
     env["PATH_INFO"] = "/users/tobi"
     response = full_application.call(env)
     assert_equal response.body, ["Hello Tobi. HTTP method is GET"]
-    File.delete controller
   end
 
   def test_response_for_route_not_defined

--- a/test/extensions_test.rb
+++ b/test/extensions_test.rb
@@ -1,0 +1,15 @@
+require_relative "test_helper"
+
+class TestExtensions < Minitest::Test
+  def test_hash_extension
+    fellow = { first_name: "Tobi", last_name: "Oduah", project: "Hemp" }
+    sliced_values = fellow.slice(:first_name, :last_name)
+    assert_equal sliced_values.length, 2
+    assert_equal sliced_values, first_name: "Tobi", last_name: "Oduah"
+  end
+
+  def test_object_extension
+    invalid_class = InvalidClass
+    assert_equal invalid_class, nil
+  end
+end

--- a/test/orm_full_test.rb
+++ b/test/orm_full_test.rb
@@ -1,0 +1,88 @@
+require_relative "test_helper"
+
+class TestOrmApplication < Minitest::Test
+  attr_reader :model, :folder
+
+  i_suck_and_my_tests_are_order_dependent!
+
+  def setup
+    set_up_full_app_and_routes
+  end
+
+  def teardown
+    File.delete @model
+  end
+
+  def set_up_full_app_and_routes
+    setup_instance_vars
+    create_model_file
+  end
+
+  def setup_instance_vars
+    @model = "wrap.rb"
+  end
+
+  def create_model_file
+    File.open(model, "w") do |file|
+      file.write(model_class_body)
+      current_dir = File.expand_path("..", file)
+      $LOAD_PATH.unshift current_dir
+    end
+  end
+
+  def model_class_body
+    <<-STRING
+      require "hemp/base_record"
+      class Wrap < Hemp::BaseRecord
+        to_table :wraps
+        property :id, type: :integer, primary_key: true
+        property :price, type: :integer, nullable: false
+        property :dealer_name, type: :text, nullable: false
+
+        create_table
+      end
+    STRING
+  end
+
+  def test_instantiating_model_returns_an_instance_of_the_model
+    wrap = Wrap.new
+    assert_instance_of Wrap, wrap
+  end
+
+  def test_instantiating_model_with_attributes_hash
+    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
+    assert_equal wrap.dealer_name, "Skinny"
+    assert_equal wrap.price, 1000
+  end
+
+  def test_saving_records
+    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
+    id = wrap.save
+    assert 1, Wrap.count
+    assert_includes Wrap.all, Wrap.find(id)
+
+    Wrap.destroy_all
+  end
+
+  def test_updating_a_record
+    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
+    id = wrap.save
+    wrap.price = 1500
+    wrap.update
+
+    assert_equal Wrap.find(id).price, 1500
+  end
+
+  def test_destroying_a_record
+    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
+    wrap.destroy
+    assert_empty Wrap.all
+  end
+
+  def test_destroying_all_records
+    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
+    wrap.save
+    Wrap.destroy_all
+    assert_empty Wrap.all
+  end
+end

--- a/test/route_syntax_error_test.rb
+++ b/test/route_syntax_error_test.rb
@@ -8,7 +8,7 @@ class TestRouteSyntaxError < Minitest::Test
     raise RouteError.new method_path
   rescue RouteError => e
     assert_equal e.message, "Error while parsing routes. "\
-      "See line containing #{method_path}. "
+      "See line containing - '#{method_path}'. "
   end
 
   def test_route_syntax_error_with_custom_message
@@ -17,6 +17,6 @@ class TestRouteSyntaxError < Minitest::Test
     raise RouteError.new method_path, custom_message
   rescue RouteError => e
     assert_equal e.message, "Error while parsing routes. "\
-      "See line containing #{method_path}. #{custom_message}"
+      "See line containing - '#{method_path}'. #{custom_message}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,13 +1,16 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
-require "simplecov"
-SimpleCov.start
+# require "simplecov"
+# SimpleCov.start
 require "hemp"
-require "hemp/routing/base"
-require "hemp/routing/route"
-require "hemp/routing/route_syntax_error"
-require "mocha/mini_test"
 require "minitest/spec"
 require "minitest/autorun"
 require "minitest/unit"
+require "fileutils"
+
+class MyTest < Minitest::Unit
+  after_tests do
+    FileUtils.rm_rf "db"
+  end
+end


### PR DESCRIPTION
Why?
Set up ORM support for the Hemp web framework. Allows apps using the framework to create models, and provides features to help persist models by storing to database.

How?
An SqlHelper class was introduced to handle executing SQL requests on specified database file. Classes were added to perform common ORM functionalities. A model object in Hemp apps would have to inherit from these classes in order to enjoy ORM features.

https://www.pivotaltracker.com/story/show/111809308