### PR TITLE
Add Create method to RecordInterface

### DIFF
--- a/lib/hemp/orm/record_interface.rb
+++ b/lib/hemp/orm/record_interface.rb
@@ -12,6 +12,13 @@ module Hemp
           property :id, type: :integer, primary_key: true
         end
 
+        def create(hash_arg)
+          new_model = const_get(name).new(hash_arg)
+          new_model.save
+
+          new_model
+        end
+
         def property(name, options)
           @properties ||= []
           new_property = Property.new(name, options)

--- a/test/orm_full_test.rb
+++ b/test/orm_full_test.rb
@@ -55,22 +55,19 @@ class TestOrmApplication < Minitest::Test
     assert_equal wrap.price, 1000
   end
 
-  def test_saving_records
-    wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
-    id = wrap.save
+  def test_creating_records
+    wrap = Wrap.create(price: 1000, dealer_name: "Skinny")
     assert 1, Wrap.count
-    assert_includes Wrap.all, Wrap.find(id)
-
+    assert_includes Wrap.all, Wrap.find(wrap.id)
     Wrap.destroy_all
   end
 
   def test_updating_a_record
     wrap = Wrap.new(price: 1000, dealer_name: "Skinny")
-    id = wrap.save
+    wrap.save
     wrap.price = 1500
     wrap.update
-
-    assert_equal Wrap.find(id).price, 1500
+    assert_equal Wrap.find(wrap.id).price, 1500
   end
 
   def test_destroying_a_record


### PR DESCRIPTION
Why?
Allows controllers create models and save to db directly, without first having to instantiate and then call save.

How?
Added method to RecordInterface which accepts hash argument of model attributes, instantiates the model, saves it to db, and then returns the model instance.

https://www.pivotaltracker.com/story/show/112743735